### PR TITLE
Skip existing stablehlo file creation

### DIFF
--- a/official/nlp/tools/collect_all_stablehlo.py
+++ b/official/nlp/tools/collect_all_stablehlo.py
@@ -48,6 +48,9 @@ def main(_):
             for exp in experiments:
                 outfile = os.path.join(
                     config_dir, exp.replace("/", "_") + ".stablehlo")
+                if os.path.exists(outfile):
+                    print(f"Skipping {outfile}, already exists")
+                    continue
                 cmd = [
                     sys.executable,
                     "-m",


### PR DESCRIPTION
## Summary
- skip stablehlo generation in `collect_all_stablehlo.py` if output already exists

## Testing
- `python -m py_compile official/nlp/tools/collect_all_stablehlo.py`

------
https://chatgpt.com/codex/tasks/task_e_68437eeec1a083278f61c079c3ac1a31